### PR TITLE
stript tags from title, site-name and description

### DIFF
--- a/opengraph.php
+++ b/opengraph.php
@@ -176,7 +176,7 @@ function opengraph_default_title( $title ) {
 		$title = get_the_archive_title();
 	}
 
-	return esc_attr( $title );
+	return wp_strip_all_tags( $title );
 }
 
 
@@ -194,7 +194,7 @@ function opengraph_default_type( $type ) {
 		}
 	}
 
-	return esc_attr( $type );
+	return $type;
 }
 
 
@@ -358,7 +358,7 @@ function opengraph_default_sitename( $name ) {
 		$name = get_bloginfo( 'name' );
 	}
 
-	return esc_attr( $name );
+	return wp_strip_all_tags( $name );
 }
 
 
@@ -395,7 +395,7 @@ function opengraph_default_description( $description, $length = 55 ) {
 	$description = strip_tags( strip_shortcodes( $description ) );
 	$description = opengraph_trim_text( $description, $length );
 
-	return esc_attr( $description );
+	return wp_strip_all_tags( $description );
 }
 
 
@@ -436,7 +436,7 @@ function twitter_default_card( $card ) {
 		}
 	}
 
-	return esc_attr( $card );
+	return $card;
 }
 
 
@@ -463,7 +463,7 @@ function twitter_default_creator( $creator ) {
 		$creator = '@' . $matches[1];
 	}
 
-	return esc_attr( $creator );
+	return $creator;
 }
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: willnorris, pfefferle
 Tags: social, opengraph, ogp, facebook
 Requires at least: 2.3
-Tested up to: 6.3
-Stable tag: 1.11.1
+Tested up to: 6.4
+Stable tag: 1.11.2
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0.html
 
@@ -62,14 +62,17 @@ The plugin populates the meta 'name' attribute alongside the 'property' attribut
 
 Project maintained on github at [willnorris/wordpress-opengraph](https://github.com/willnorris/wordpress-opengraph).
 
-= version 1.11.1 (April 03, 2023) =
+= version 1.11.2 (Nov 13, 2023) =
+ - stript tags from title, site-name and description
+
+= version 1.11.1 (Apr 03, 2023) =
  - fixed a typo
 
-= version 1.11.0 (October 21, 2021) =
+= version 1.11.0 (Oct 21, 2021) =
  - fixed attachment issue
  - fixed PHP 7.4 issue
 
-= version 1.10.0 (April 20, 2020) =
+= version 1.10.0 (Apr 20, 2020) =
  - basic video support
  - basic audio support
 


### PR DESCRIPTION
in the current version, HTML will only be escaped, so it will be falsely displayed on for example social networks like mastodon: https://mastodon.social/@pfefferle/111402121792176051